### PR TITLE
Replace (SDL_INIT_EVERYTHING).

### DIFF
--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -12,6 +12,7 @@
 #include "classes/RunnerJNILib.h"
 #include "khronos/gles2.h"
 #include "libyoyo.h"
+
 namespace fs = std::filesystem;
 
 extern DynLibFunction symtable_libc[];
@@ -68,6 +69,7 @@ so_module stdcpp = {};
 so_module libyoyo = {};
 
 int RunnerJNILib_MoveTaskToBackCalled = 0;
+
 int main(int argc, char *argv[])
 {
     fs::path work_dir, apk_path;
@@ -124,7 +126,12 @@ int main(int argc, char *argv[])
     String *pkg_dir_arg = (String *)env->NewStringUTF("com.johnny.loader");
     printf("apk_path %s save_dir %s pkg_dir %s\n", apk_path_arg->str, save_dir_arg->str, pkg_dir_arg->str);
 
-    SDL_Init(SDL_INIT_EVERYTHING);
+    // Initialize SDL with video, audio, joystick, and controller support
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) != 0) {
+        fatal_error("SDL could not initialize! SDL_Error: %s\n", SDL_GetError());
+        return -1;
+    }
+
     SDL_Window *sdl_win;
     SDL_GLContext sdl_ctx;
 


### PR DESCRIPTION
Trimui's Tina linux' SDL build does not work properly with (SDL_INIT_EVERYTHING). In this case it broke SDL inputs. By replacing it with individual initializations it works as expected. 