### PR TITLE
Use gamedata for the savedir and enable building on wsl debian bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Corrections, fixes, issue reports and optimizations are always welcome.
 ### Building and Deploying [example]:
 -----
 
+`git clone <repository url> --recursive`
+
 - `ARCH`: Specify the architecture, e.g.: `aarch64-linux-gnu`
 - `LLVM_FILE`: Specify the LLVM Clang library file, e.g.: `/usr/lib/llvm-9/lib/libclang-9.so.1` for clang-9.
 - `LLVM_INC`: Specify the path for LLVM includes for your architecture, e.g.: `aarch64-linux-gnu`.
@@ -20,6 +22,17 @@ Corrections, fixes, issue reports and optimizations are always welcome.
 
 ```bash
 make -f Makefile.gmloader ARCH=aarch64-linux-gnu
+```
+
+Or, for a debian bullseye chroot within wsl2:
+
+```bash
+make -f Makefile.gmloader \
+ARCH=aarch64-linux-gnu \
+LLVM_FILE=/usr/lib/llvm-11/lib/libclang-11.so.1 \
+LLVM_INC=/usr/aarch64-linux-gnu/include/c++/10/aarch64-linux-gnu \
+-j$(nproc)
+python3 scripts/generate_libc.py aarch64-linux-gnu --llvm-includes /usr/aarch64-linux-gnu/include/c++/10/aarch64-linux-gnu --llvm-library-file "/usr/lib/llvm-11/lib/libclang-11.so.1"
 ```
 
 In order to deploy, you must copy the `lib` redist folder in the application's folder,

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -77,10 +77,9 @@ int RunnerJNILib_MoveTaskToBackCalled = 0;
 
 int main(int argc, char *argv[])
 {
-    fs::path work_dir, apk_path;
-    work_dir = fs::current_path();
-    work_dir = fs::canonical(fs::current_path()) / "";
-    apk_path = work_dir / "game.apk";
+    fs::path work_dir = fs::canonical(fs::current_path());
+    fs::path save_dir = work_dir / "gamedata/";
+    fs::path apk_path = work_dir / "game.apk";
 
     int err;
     zip_t *apk = zip_open(apk_path.c_str(), ZIP_RDONLY, &err);
@@ -130,7 +129,7 @@ int main(int argc, char *argv[])
     patch_mouse(&libyoyo);
 
     String *apk_path_arg = (String *)env->NewStringUTF(apk_path.c_str());
-    String *save_dir_arg = (String *)env->NewStringUTF(work_dir.c_str());
+    String *save_dir_arg = (String *)env->NewStringUTF(save_dir.c_str());
     String *pkg_dir_arg = (String *)env->NewStringUTF("com.johnny.loader");
     printf("apk_path %s save_dir %s pkg_dir %s\n", apk_path_arg->str, save_dir_arg->str, pkg_dir_arg->str);
 

--- a/jni/classes/media_AudioTrack.cpp
+++ b/jni/classes/media_AudioTrack.cpp
@@ -33,7 +33,7 @@ AudioTrack::AudioTrack(int streamType, int sampleRateInHz, int channelConfig, in
     desired.freq = sampleRateInHz;
     desired.format = GetSDLFormat(audioFormat);
     desired.channels = (channelConfig == 4) ? 1 : 2;
-    desired.samples = 2048;
+    desired.samples = bufferSizeInBytes / GetSDLFormatBytes(audioFormat);
     desired.callback = NULL;
 
     deviceId = SDL_OpenAudioDevice(NULL, 0, &desired, &obtained, 0);


### PR DESCRIPTION
- Clean up path variables
- Add save_dir variable to point to `work_dir/gamedata`
- Update README.md to add line about cloning with submodules
- In `thunks/libc/stdio.cpp` return `vsprintf` instead of `__vsprintf_check`, which allows building in wsl debian bullseye chroot
- 
Build was tested with Undertale Yellow.

```
***************************************
*     YoYo Games Runner v1.0(0)[r32908]    *
***************************************	 
RunnerLoadGame: game.droid
not in bundleRunnerLoadGame() - /storage/roms/ports/utyellow/gamedata/game.droid
YYG Game launching. Game file: /storage/roms/ports/utyellow/gamedata/game.droid
Checking if INIFile exists at /storage/roms/ports/utyellow/gamedata/options.ini
Reading File /storage/roms/ports/utyellow/gamedata/game.droid
Loaded File /storage/roms/ports/utyellow/gamedata/game.droid(159830628)
```