### PR TITLE
Fix wrong audio buffer size in AudioTrack to SDL_OpenAudioDevice function

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "3rdparty/libmd"]
 	path = 3rdparty/libmd
 	url = https://gitlab.freedesktop.org/libbsd/libmd
+[submodule "3rdparty/json"]
+	path = 3rdparty/json
+	url = https://github.com/nlohmann/json.git

--- a/Makefile.gmloader
+++ b/Makefile.gmloader
@@ -16,7 +16,7 @@ LIBS=\
 
 # General compilation flags
 OPTM?=-Os
-COMMONFLAGS=-Wno-strict-aliasing -Werror=return-type -I. -I./thunks/ -I./loader/ -I./gmloader/ -I./build/${ARCH}/thunks/libc -I./jni/ ${OPTM} -MMD
+COMMONFLAGS=-Wno-strict-aliasing -Werror=return-type -I. -I./thunks/ -I./loader/ -I./gmloader/ -I./build/${ARCH}/thunks/libc -I./jni/ -I./3rdparty/json/include ${OPTM} -MMD
 CFLAGS=$(shell ${PKG_CONFIG} sdl2 --cflags) ${COMMONFLAGS}
 CXXFLAGS=-std=gnu++2a -fuse-cxa-atexit $(shell ${PKG_CONFIG} sdl2 --cflags) ${COMMONFLAGS}
 LDFLAGS=-L3rdparty/libbsd/src/.libs ${OPTM}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ The android libraries can be debugged with `gdb` using a breakpoint trick - chec
 
 For this to be possible, you must extract the libraries from the APK into the application's library folder following the same structure as you would on the APK.
 
+### Config file
+-----
+`config.json` can be used to configure some parameters. Here is an exemple:
+
+```json
+{
+    "save_dir" : "gamedata",
+    "apk_path" : "my_game.apk",
+    "show_cursor": false
+}
+```
+
 ### License:
 -----
 This is free software. The source files in this repository are released under the [GPLv2 License](LICENSE.md), see the license file for more information.

--- a/gmloader/configuration.cpp
+++ b/gmloader/configuration.cpp
@@ -12,7 +12,7 @@ int read_config_file(const char* path){
 
     // default values
     gmloader_config.apk_path = "game.apk";
-    gmloader_config.save_dir = "gamedata";
+    gmloader_config.save_dir = "";
     gmloader_config.show_cursor = true;
 
     try{

--- a/gmloader/configuration.cpp
+++ b/gmloader/configuration.cpp
@@ -1,0 +1,62 @@
+#include "configuration.h"
+
+#include "platform.h"
+
+gmloader::config gmloader_config;
+
+int read_config_file(const char* path){
+    std::ifstream config_file(path);
+    json config_json;
+
+    int p_loaded = 0;
+
+    // default values
+    gmloader_config.apk_path = "game.apk";
+    gmloader_config.save_dir = "gamedata";
+    gmloader_config.show_cursor = true;
+
+    try{
+        config_json = json::parse(config_file);
+    }catch (const json::parse_error& e){
+        warning("%s: parse error (%s)\n", path, e.what());
+        return -1;
+    } 
+
+
+    try{
+        config_json.at("save_dir").get_to(gmloader_config.save_dir);
+        p_loaded++;
+    }catch (const json::out_of_range& e){
+        printf("%s: save_dir default value\n", path);
+    }catch (const json::type_error& e){
+        warning("%s: save_dir type error\n", path);
+    }
+    
+    try{
+        config_json.at("apk_path").get_to(gmloader_config.apk_path);
+        p_loaded++;
+    }catch (const json::out_of_range& e){
+        printf("%s: apk_path default value\n", path);
+    }catch (const json::type_error& e){
+        warning("%s: apk_path type error\n", path);
+    }
+
+
+
+    try{
+        config_json.at("show_cursor").get_to(gmloader_config.show_cursor);
+        p_loaded++;
+    }catch (const json::out_of_range& e){
+        printf("%s: show_cursor default value\n", path);
+    }catch (const json::type_error& e){
+        warning("%s: show_cursor type error\n", path);
+    }
+
+    return p_loaded;
+}
+
+void show_config(){
+    printf("save_dir=%s\n",gmloader_config.save_dir.c_str());
+    printf("apk_path=%s\n",gmloader_config.apk_path.c_str());
+    printf("show_cursor=%d\n",gmloader_config.show_cursor);
+}

--- a/gmloader/configuration.cpp
+++ b/gmloader/configuration.cpp
@@ -1,10 +1,11 @@
 #include "configuration.h"
-
 #include "platform.h"
 
 gmloader::config gmloader_config;
 
 int read_config_file(const char* path){
+    printf("Loading config file (%s)\n", path);
+
     std::ifstream config_file(path);
     json config_json;
 
@@ -18,45 +19,56 @@ int read_config_file(const char* path){
     try{
         config_json = json::parse(config_file);
     }catch (const json::parse_error& e){
-        warning("%s: parse error (%s)\n", path, e.what());
+        warning("\tparse error (%s)\n", e.what());
         return -1;
     } 
-
 
     try{
         config_json.at("save_dir").get_to(gmloader_config.save_dir);
         p_loaded++;
     }catch (const json::out_of_range& e){
-        printf("%s: save_dir default value\n", path);
+        // default value
     }catch (const json::type_error& e){
-        warning("%s: save_dir type error\n", path);
+        warning("\tsave_dir type error\n");
     }
+    printf("\tsave_dir = %s\n",gmloader_config.save_dir.c_str());
     
     try{
         config_json.at("apk_path").get_to(gmloader_config.apk_path);
         p_loaded++;
     }catch (const json::out_of_range& e){
-        printf("%s: apk_path default value\n", path);
+        // default value
     }catch (const json::type_error& e){
-        warning("%s: apk_path type error\n", path);
+        warning("\tapk_path type error\n");
     }
-
-
+    printf("\tapk_path = %s\n",gmloader_config.apk_path.c_str());
 
     try{
         config_json.at("show_cursor").get_to(gmloader_config.show_cursor);
         p_loaded++;
     }catch (const json::out_of_range& e){
-        printf("%s: show_cursor default value\n", path);
+        // default value
     }catch (const json::type_error& e){
-        warning("%s: show_cursor type error\n", path);
+        warning("\tshow_cursor type error\n");
     }
+    printf("\tshow_cursor = %d\n",gmloader_config.show_cursor);
 
     return p_loaded;
 }
 
 void show_config(){
-    printf("save_dir=%s\n",gmloader_config.save_dir.c_str());
-    printf("apk_path=%s\n",gmloader_config.apk_path.c_str());
-    printf("show_cursor=%d\n",gmloader_config.show_cursor);
+    printf("config: save_dir = %s\n",gmloader_config.save_dir.c_str());
+    printf("config: apk_path = %s\n",gmloader_config.apk_path.c_str());
+    printf("config: show_cursor = %d\n",gmloader_config.show_cursor);
+}
+
+fs::path get_absolute_path(const char* path, fs::path work_dir){
+
+    fs::path fs_path = fs::path(path);
+    
+    if ( fs_path.is_relative() ){
+        fs_path = work_dir / fs_path;
+    }
+
+    return fs_path;
 }

--- a/gmloader/configuration.h
+++ b/gmloader/configuration.h
@@ -1,0 +1,17 @@
+#include <string>
+#include <fstream>
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+namespace gmloader {
+    // a simple struct to model a person
+    struct config {
+        std::string save_dir;
+        std::string apk_path;
+        bool show_cursor;
+    };
+}
+
+int read_config_file(const char* path);
+
+void show_config();

--- a/gmloader/configuration.h
+++ b/gmloader/configuration.h
@@ -1,10 +1,12 @@
+#include <filesystem>
 #include <string>
 #include <fstream>
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+namespace fs = std::filesystem;
+
 namespace gmloader {
-    // a simple struct to model a person
     struct config {
         std::string save_dir;
         std::string apk_path;
@@ -15,3 +17,5 @@ namespace gmloader {
 int read_config_file(const char* path);
 
 void show_config();
+
+fs::path get_absolute_path(const char* path, fs::path work_dir);

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -86,9 +86,9 @@ int main(int argc, char *argv[])
 
     show_config();
 
-    fs::path work_dir, apk_path;
-    work_dir = fs::current_path();
+    fs::path work_dir, save_dir, apk_path;
     work_dir = fs::canonical(fs::current_path()) / "";
+    save_dir = work_dir / gmloader_config.save_dir.c_str();
     apk_path = work_dir / gmloader_config.apk_path.c_str();
 
     int err;
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
     }
 
     String *apk_path_arg = (String *)env->NewStringUTF(apk_path.c_str());
-    String *save_dir_arg = (String *)env->NewStringUTF(work_dir.c_str());
+    String *save_dir_arg = (String *)env->NewStringUTF(save_dir.c_str());
     String *pkg_dir_arg = (String *)env->NewStringUTF("com.johnny.loader");
     printf("apk_path %s save_dir %s pkg_dir %s\n", apk_path_arg->str, save_dir_arg->str, pkg_dir_arg->str);
 

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -78,19 +78,22 @@ int RunnerJNILib_MoveTaskToBackCalled = 0;
 
 int main(int argc, char *argv[])
 {
-    printf("Loading config file (%s)\n", CONFIG_FILE);
-    
-    if( read_config_file(CONFIG_FILE) < 0 ){
+
+    fs::path work_dir, config_file_path, save_dir, apk_path;
+    work_dir = fs::canonical(fs::current_path()) / "";
+    config_file_path = work_dir / CONFIG_FILE;
+
+    if( read_config_file(config_file_path.c_str()) < 0 ){
         warning("Error while loading the config file\n");
     }
 
-    show_config();
+    save_dir = get_absolute_path(gmloader_config.save_dir.c_str(), work_dir) / "";
+    apk_path = get_absolute_path(gmloader_config.apk_path.c_str(), work_dir);
 
-    fs::path work_dir, save_dir, apk_path;
-    work_dir = fs::canonical(fs::current_path()) / "";
-    save_dir = work_dir / gmloader_config.save_dir.c_str() / "";
-    apk_path = work_dir / gmloader_config.apk_path.c_str();
-
+    printf("work_dir=%s\n",work_dir.c_str());
+    printf("save_dir=%s\n",save_dir.c_str());
+    printf("apk_path=%s\n",apk_path.c_str());
+    
     int err;
     zip_t *apk = zip_open(apk_path.c_str(), ZIP_RDONLY, &err);
     if (apk == NULL) {

--- a/gmloader/main.cpp
+++ b/gmloader/main.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
 
     fs::path work_dir, save_dir, apk_path;
     work_dir = fs::canonical(fs::current_path()) / "";
-    save_dir = work_dir / gmloader_config.save_dir.c_str();
+    save_dir = work_dir / gmloader_config.save_dir.c_str() / "";
     apk_path = work_dir / gmloader_config.apk_path.c_str();
 
     int err;

--- a/jni/classes/media_AudioTrack.cpp
+++ b/jni/classes/media_AudioTrack.cpp
@@ -28,12 +28,11 @@ static int GetSDLFormatBytes(int audioFormat)
 
 AudioTrack::AudioTrack(int streamType, int sampleRateInHz, int channelConfig, int audioFormat, int bufferSizeInBytes, int mode)
 {
-    
     SDL_zero(desired);
     desired.freq = sampleRateInHz;
     desired.format = GetSDLFormat(audioFormat);
     desired.channels = (channelConfig == 4) ? 1 : 2;
-    desired.samples = 2048;
+    desired.samples = bufferSizeInBytes / GetSDLFormatBytes(audioFormat);
     desired.callback = NULL;
 
     deviceId = SDL_OpenAudioDevice(NULL, 0, &desired, &obtained, 0);


### PR DESCRIPTION
AudioTrack uses buffer size in Bytes while SDL use buffer size in sample unit so it needs some calculation. Here is the fix.

It also includes a proposal for adding the support of a json config file.